### PR TITLE
Refactor/rename omniset to allset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AllSet SDK
 
-Official TypeScript SDK for the AllSet bridge. Bridge tokens between Fast chain and EVM chains (Arbitrum Sepolia, Ethereum Sepolia).
+Official TypeScript SDK for the AllSet bridge. Bridge tokens between Fast chain and supported EVM routes, with the current branch focused on Arbitrum Sepolia and Fast testnet flows.
 
 ## Install
 
@@ -26,6 +26,7 @@ const result = await allsetProvider.bridge({
   toChain: 'fast',
   fromToken: 'USDC',
   toToken: 'fastUSDC',
+  fromDecimals: 6,
   amount: '1000000', // 1 USDC (6 decimals)
   senderAddress: '0xYourEvmAddress',
   receiverAddress: 'fast1yourfastaddress',
@@ -41,12 +42,8 @@ console.log(result.txHash);
 import { createFastWallet } from '@fastxyz/allset-sdk';
 
 const wallet = createFastWallet();
-console.log(wallet);
-// {
-//   privateKey: '...',
-//   publicKey: '...',
-//   address: 'fast1...'
-// }
+console.log(wallet.address);
+// Persist wallet.privateKey and wallet.publicKey securely.
 ```
 
 Store that keypair securely, then use it with `createFastClient()`:
@@ -64,6 +61,7 @@ const result = await allsetProvider.bridge({
   toChain: 'arbitrum',
   fromToken: 'fastUSDC',
   toToken: 'USDC',
+  fromDecimals: 6,
   amount: '1000000', // 1 USDC (6 decimals)
   senderAddress: fastClient.address!,
   receiverAddress: '0xYourEvmAddress',
@@ -86,11 +84,16 @@ Best practice: generate the Fast wallet once, store the private/public keys in y
 
 ## Supported Networks
 
-| Chain | Network | Chain ID |
-|-------|---------|----------|
-| Arbitrum | Sepolia | 421614 |
-| Ethereum | Sepolia | 11155111 |
-| Fast | Testnet | - |
+Current SDK implementation in this branch:
+
+- Testnet-only bridge flows
+- Arbitrum Sepolia (`421614`) + Fast testnet
+- Token mapping for `USDC` <-> `fastUSDC`
+
+Environment target matrix for AllSet deployments:
+
+- Mainnet: Polygon, Arbitrum, Base with `USDC` -> `fastUSDC`
+- Testnet: Sepolia, Arbitrum Sepolia, Tempo with testnet `USDC` -> `testUSDC`
 
 ## Documentation
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,7 +1,7 @@
 /**
  * bridge.ts — AllSet bridge provider
  *
- * Bridges between Fast chain and EVM chains (Ethereum Sepolia, Arbitrum Sepolia).
+ * Bridges between Fast chain and the SDK's supported EVM routes.
  *
  * Two directions:
  *   Deposit  (EVM → Fast): call bridge.deposit(token, amount, receiver) on the EVM bridge contract

--- a/src/evm-executor.ts
+++ b/src/evm-executor.ts
@@ -23,8 +23,8 @@ import type { EvmTxExecutor } from './types.js';
  * @example
  * ```ts
  * const wallet = createEvmWallet();
- * console.log(wallet.address);    // 0x...
- * console.log(wallet.privateKey); // 0x... (keep secret!)
+ * console.log(wallet.address); // 0x...
+ * // Persist wallet.privateKey securely. Never log or commit it.
  *
  * // Use with createEvmExecutor
  * const executor = createEvmExecutor(wallet.privateKey, rpcUrl, chainId);

--- a/src/fast-client.ts
+++ b/src/fast-client.ts
@@ -26,6 +26,9 @@ const CROSS_SIGN_URL = 'https://staging.cross-sign.allset.fastset.xyz';
 
 function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length % 2 !== 0) {
+    throw new Error(`Invalid hex string: ${hex}`);
+  }
   const bytes = new Uint8Array(clean.length / 2);
   for (let i = 0; i < bytes.length; i++) {
     bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
@@ -197,10 +200,25 @@ export function createFastWallet(): FastWallet {
  */
 export function createFastClient(options: FastClientOptions): FastClient {
   const { privateKey, publicKey, rpcUrl = DEFAULT_FAST_RPC_URL, crossSignUrl = CROSS_SIGN_URL } = options;
-  
-  const address = pubkeyToFastAddress(publicKey);
   const privateKeyBytes = hexToBytes(privateKey);
   const publicKeyBytes = hexToBytes(publicKey);
+  if (privateKeyBytes.length !== 32) {
+    throw new Error('Fast privateKey must be a 32-byte hex string');
+  }
+  if (publicKeyBytes.length !== 32) {
+    throw new Error('Fast publicKey must be a 32-byte hex string');
+  }
+
+  const derivedPublicKey = ed.getPublicKey(privateKeyBytes);
+  const normalizedPublicKey = bytesToHex(publicKeyBytes);
+  const normalizedDerivedPublicKey = bytesToHex(derivedPublicKey);
+  derivedPublicKey.fill(0);
+
+  if (normalizedPublicKey !== normalizedDerivedPublicKey) {
+    throw new Error('Fast publicKey does not match the supplied privateKey');
+  }
+
+  const address = pubkeyToFastAddress(normalizedPublicKey);
 
   async function getNonce(): Promise<number> {
     const payload = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @fastxyz/allset-sdk — AllSet bridge SDK
  *
- * Bridges assets between Fast chain and EVM chains (Arbitrum Sepolia, Ethereum Sepolia).
+ * Bridges assets between Fast chain and supported EVM routes.
  */
 
 export { allsetProvider } from './bridge.js';

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -115,6 +115,19 @@ test('createFastWallet generates a usable Fast wallet', () => {
   assert.notEqual(wallet.address, wallet2.address, 'should generate unique addresses');
 });
 
+test('createFastClient rejects mismatched Fast keypairs', () => {
+  const wallet = createFastWallet();
+  const otherWallet = createFastWallet();
+
+  assert.throws(
+    () => createFastClient({
+      privateKey: wallet.privateKey,
+      publicKey: otherWallet.publicKey,
+    }),
+    /publicKey does not match/,
+  );
+});
+
 test('createFastClient preserves exact timestamp_nanos in submit and evmSign payloads', async (t) => {
   const originalFetch = globalThis.fetch;
   const originalDateNow = Date.now;
@@ -123,8 +136,9 @@ test('createFastClient preserves exact timestamp_nanos in submit and evmSign pay
   let crossSignBody = '';
 
   const expectedTimestamp = 1_730_000_000_123_000_000n;
-  const senderBytes = new Array(32).fill(0x22);
   const tokenIdBytes = new Array(32).fill(0x07);
+  const wallet = createFastWallet();
+  const senderBytes = Array.from(Buffer.from(wallet.publicKey, 'hex'));
 
   Date.now = () => 1_730_000_000_123;
 
@@ -168,8 +182,8 @@ test('createFastClient preserves exact timestamp_nanos in submit and evmSign pay
   });
 
   const client = createFastClient({
-    privateKey: '11'.repeat(32),
-    publicKey: '22'.repeat(32),
+    privateKey: wallet.privateKey,
+    publicKey: wallet.publicKey,
   });
 
   const submitResult = await client.submit({


### PR DESCRIPTION
## Summary

AllSet SDK - TypeScript SDK for bridging between Fast network and EVM chains via OmniSet infrastructure.

## Changes

### Core Refactoring

• Rename OmniSet to AllSet (5c32ee3) - Update branding throughout codebase

### New Features

• Add createEvmWallet() (686eaca) - Generate new EVM wallets for bridging
• FastClient implementation (61319f8) - Wrapper for @fastxyz/sdk with precision fix for amounts

### Bug Fixes (Withdraw Flow)

1. Add deadline to IntentClaim (b29c82f)  • Required field: 1 hour from current time

2. Fix transferFastTxId (bcf4f82)  • Use txHash directly (keccak256 of BCS tx)
  • Previously incorrectly used hashMessage(txBytes)

3. Add missing relayer fields (4dd5893)  • Include committee signatures and deadline in relayer request body

### Config Updates

• Update fastUSDC token ID (c842d0b) - Use staging token: 0x1b48766165f2cc84292d8c06b0523e1eefd7586049be0f82249c002f88a409ef
• Update relayer URLs - Point to staging.omniset.fastset.xyz

### Documentation

• README updates (4b03a6a) - Add withdraw usage examples and precision warning

### Testing

SDK implementation verified - relayer accepts requests. Infrastructure-side processing pending.